### PR TITLE
resetable: made reset start and stop methods 'virtual', so they can be overridden in a child class.

### DIFF
--- a/src/components/scc/resetable.h
+++ b/src/components/scc/resetable.h
@@ -37,7 +37,7 @@ public:
      * @brief distributes the begin of the reset to all registered components and set the reset state
      *
      */
-    void reset_start() {
+    virtual void reset_start() {
         _in_reset = true;
         for(auto res : resources)
             res->reset();
@@ -47,7 +47,7 @@ public:
      * @brief distributes the end of the reset to all registered components and finishes the reset state
      *
      */
-    void reset_stop() {
+    virtual void reset_stop() {
         for(auto res : resources)
             res->reset();
         _in_reset = false;


### PR DESCRIPTION
I'd appreciate the possibility to _override_ the implementation of `resetable::reset_start()` and `resetable::reset_stop()` in a child class of `resetable`.
(In the current implementation only _shadowing_ is possible, but this will not work for polymorphism)