### PR TITLE
remove include from namespace

### DIFF
--- a/src/common/util/logging.h
+++ b/src/common/util/logging.h
@@ -264,10 +264,12 @@ class DEFAULT {};
     LOGGER(CATEGORY)().get(::logging::LEVEL, #CATEGORY)
 #endif
 #if defined(WIN32)
+} // namespace logging
 
 #include <array>
 #include <windows.h>
 
+namespace logging {
 inline std::string now_time() {
     const int MAX_LEN = 200;
     char buffer[MAX_LEN];


### PR DESCRIPTION
Including files inside a namespace puts everything from those files in the namespace causing compiling errors.