### PR TITLE
Fix fmt 10.x+ compatibility issue in vcd_trace.hh

### DIFF
--- a/src/sysc/scc/trace/vcd_trace.hh
+++ b/src/sysc/scc/trace/vcd_trace.hh
@@ -53,7 +53,7 @@ inline void vcdEmitValueChange64(FPTR os, std::string const& handle, unsigned bi
 
 template<typename T>
 inline void vcdEmitValueChangeReal(FPTR os, std::string const& handle, unsigned bits, T val){
-    auto buf = fmt::format("r{:.16g} {}\n", val, handle);
+    auto buf = fmt::format("r{:.16g} {}\n", static_cast<double>(val), handle);
     FWRITE(buf.c_str(), 1, buf.size(), os);
 }
 


### PR DESCRIPTION
SCC fails to compile with `fmt` 10 due to and explicit formatter for `sc_dt::sc_fxval_fast` not being found:
```
fmt20600bf402265/p/include/fmt/core.h:1576:63: error: ‘fmt::v10::detail::type_is_unformattable_for<sc_dt::sc_fxval_fast, char> _’ has incomplete type
 1576 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
fmt20600bf402265/p/include/fmt/core.h:1580:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1580 |       formattable,
      |       ^~~~~~~~~~~
```
This PR suggests a workaround that simply casts the value to `double` before formatting.

This came up in an update for the SCC Conan recipe: https://github.com/conan-io/conan-center-index/pull/18715