### PR TITLE
check RapidJSON_FOUND before add_subdirectory

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(fst)
-add_subdirectory(rapidjson-1.1)
+if(NOT RapidJSON_FOUND)
+    add_subdirectory(rapidjson-1.1)
+endif()
 ###############################################################################
 # build tlm-interfaces
 ###############################################################################


### PR DESCRIPTION
This fix enables building with a pre-existing RapidJSON component