### PR TITLE
make tlm_signal array iteration use auto instead of size_t

### DIFF
--- a/src/sysc/tlm/scc/tlm_signal.h
+++ b/src/sysc/tlm/scc/tlm_signal.h
@@ -93,7 +93,7 @@ template <typename SIG, typename TYPES, int N>
 tlm_sync_enum tlm_signal<SIG, TYPES, N>::nb_transport_fw(payload_type& gp, phase_type& phase, sc_core::sc_time& delay) {
     que.notify(gp.get_value(), delay);
     auto& p = out.get_base_port();
-    for(size_t i = 0; i < p.size(); ++i) {
+    for(auto i = 0; i < p.size(); ++i) {
         p.get_interface(i)->nb_transport_fw(gp, phase, delay);
     }
     return TLM_COMPLETED;
@@ -102,7 +102,7 @@ tlm_sync_enum tlm_signal<SIG, TYPES, N>::nb_transport_fw(payload_type& gp, phase
 template <typename SIG, typename TYPES, int N>
 tlm_sync_enum tlm_signal<SIG, TYPES, N>::nb_transport_bw(payload_type& gp, phase_type& phase, sc_core::sc_time& delay) {
     auto& p = in.get_base_port();
-    for(size_t i = 0; i < p.size(); ++i) {
+    for(auto i = 0; i < p.size(); ++i) {
         p.get_interface(i)->nb_transport_bw(gp, phase, delay);
     }
     return TLM_COMPLETED;


### PR DESCRIPTION
Addresses compiler error:

error: comparison of integer expressions of
different signedness: 'std::size_t' {aka 'long
unsigned int'} and 'int' [-Werror=sign-compare]