### PR TITLE
omit the rapidjson namespace in CMakeLists.txt

### DIFF
--- a/src/sysc/CMakeLists.txt
+++ b/src/sysc/CMakeLists.txt
@@ -79,7 +79,7 @@ target_include_directories (${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> # for headers when building
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> # for client in install mode
 )
-target_link_libraries(${PROJECT_NAME} PUBLIC scc-util RapidJSON::RapidJSON spdlog::spdlog lwtr)
+target_link_libraries(${PROJECT_NAME} PUBLIC scc-util RapidJSON spdlog::spdlog lwtr)
 if(ENABLE_SQLITE)
     target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_SQLITE)
     target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/sqlite3)


### PR DESCRIPTION
When RapidJSON is added via add_subdirectory
in the parent project it does not have
a namespace.  For this method to keep working,
SCC must reference RapidJSON using the non-
namespaced name.