### PR TITLE
fixes needed to use conan2; seems applicable for other uses as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if(SystemC_FOUND)
         target_link_libraries(scc INTERFACE ${Boost_datetime_LIBRARY})
     endif()
     target_link_libraries(scc INTERFACE scc-util scc-sysc components busses scv-tr)
-    target_link_libraries(scc INTERFACE ${FMT_TARGET} spdlog::spdlog)
+    target_link_libraries(scc INTERFACE ${FMT_TARGET})
     
     set_target_properties(scc PROPERTIES
         PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/src/scc.h

--- a/src/sysc/CMakeLists.txt
+++ b/src/sysc/CMakeLists.txt
@@ -79,7 +79,10 @@ target_include_directories (${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> # for headers when building
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> # for client in install mode
 )
-target_link_libraries(${PROJECT_NAME} PUBLIC scc-util RapidJSON spdlog::spdlog lwtr)
+target_link_libraries(${PROJECT_NAME} PUBLIC scc-util RapidJSON lwtr)
+target_include_directories(${PROJECT_NAME} PUBLIC ${spdlog_INCLUDE_DIRS})
+target_compile_definitions(${PROJECT_NAME} PUBLIC -DSPDLOG_FMT_EXTERNAL)
+
 if(ENABLE_SQLITE)
     target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_SQLITE)
     target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party/sqlite3)


### PR DESCRIPTION
tested with conan2 by providing a conanfile.txt to provide dependies rather than relying on conan references inside the cmake files. 