### PR TITLE
bus_interfaces/axi: Fix AXI ID overflow.

### DIFF
--- a/src/bus_interfaces/axi/axi_initiator.cpp
+++ b/src/bus_interfaces/axi/axi_initiator.cpp
@@ -22,10 +22,11 @@
 
 using namespace axi;
 
-axi_initiator_base::axi_initiator_base(const sc_core::sc_module_name& nm, axi::pe::simple_initiator_b& pe, uint32_t width)
+axi_initiator_base::axi_initiator_base(const sc_core::sc_module_name& nm, axi::pe::simple_initiator_b& pe, uint32_t bus_width, uint32_t id_width)
 : sc_module(nm)
 , pe(pe)
-, buswidth(width) {
+, buswidth(bus_width)
+, id_cnt_max(1 << id_width) {
     SC_HAS_PROCESS(axi_initiator_base);
     // Register callback for incoming b_transport interface method call
     tsck.register_b_transport(this, &axi_initiator_base::b_transport);
@@ -36,7 +37,7 @@ axi_initiator_base::axi_initiator_base(const sc_core::sc_module_name& nm, axi::p
         sc_assert(len < (buswidth / 8) || len % (buswidth / 8) == 0);
         ext->set_length((len * 8 - 1) / buswidth);
         ext->set_burst(axi::burst_e::INCR);
-        ext->set_id(id);
+        ext->set_id(id % id_cnt_max);
     };
 }
 

--- a/src/bus_interfaces/axi/axi_initiator.h
+++ b/src/bus_interfaces/axi/axi_initiator.h
@@ -46,7 +46,7 @@ public:
 
     void b_transport(tlm::tlm_generic_payload& trans, sc_core::sc_time& delay);
 
-    axi_initiator_base(const sc_core::sc_module_name& nm, axi::pe::simple_initiator_b& pe, uint32_t width);
+    axi_initiator_base(const sc_core::sc_module_name& nm, axi::pe::simple_initiator_b& pe, uint32_t bus_width, uint32_t id_width);
 
     virtual ~axi_initiator_base() {}
 
@@ -55,16 +55,17 @@ public:
 private:
     axi::pe::simple_initiator_b& pe;
     uint32_t buswidth{0};
+    uint32_t id_cnt_max{0};
     unsigned id{0};
     std::function<void(tlm::tlm_generic_payload& p)> setup_cb;
 };
 
-template <unsigned int BUSWIDTH = 32> class axi_initiator : public axi_initiator_base {
+template <unsigned int BUSWIDTH = 32, unsigned int IDWIDTH=16> class axi_initiator : public axi_initiator_base {
 public:
     axi::axi_initiator_socket<BUSWIDTH> isck{"isck"};
 
     axi_initiator(sc_core::sc_module_name nm)
-    : axi_initiator_base(nm, pe, BUSWIDTH) {
+    : axi_initiator_base(nm, pe, BUSWIDTH, IDWIDTH) {
         pe.clk_i(clk_i);
     };
 

--- a/src/bus_interfaces/axi/pin/axi4_initiator.h
+++ b/src/bus_interfaces/axi/pin/axi4_initiator.h
@@ -55,7 +55,7 @@ struct axi4_initiator : public sc_core::sc_module,
 
     axi4_initiator(sc_core::sc_module_name const& nm, bool pipelined_wrreq = false)
     : sc_core::sc_module(nm)
-    , base(CFG::BUSWIDTH)
+    , base(CFG::BUSWIDTH, CFG::IDWIDTH)
     , pipelined_wrreq("pipelined_wrreq", pipelined_wrreq) {
         instance_name = name();
         tsckt(*this);


### PR DESCRIPTION
AXI ID is different from TLM payload ID.
We should ensure that the AXI ID does not overflow.