### PR TITLE
Add Surfer to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Here is a short list of features.
   
 * Various optimized trace file implementations   
   * compressed VCD
-  * FST (used by [GTKWave](http://gtkwave.sourceforge.net/))
+  * FST (used by [GTKWave](http://gtkwave.sourceforge.net/) and [Surfer](https://surfer-project.org/))
 
 * Tracing TLM2 Sockets
 


### PR DESCRIPTION
Shameless plug to add the Surfer waveform viewer to the readme section about FST. 