### PR TITLE
C++20 compatibility

### DIFF
--- a/.github/workflows/ci-transaction_recording.yml
+++ b/.github/workflows/ci-transaction_recording.yml
@@ -1,0 +1,44 @@
+name: CI Transaction Recording
+
+on:
+  push:
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**CMakeLists.txt'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**CMakeLists.txt'
+      - '.github/workflows/**'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cpp_std: [11, 14, 17, 20]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ python3-pip
+          pip3 install "conan<2.0"
+
+      - name: Configure
+        run: >
+          cmake -S . -B build
+          -DCMAKE_CXX_STANDARD=${{ matrix.cpp_std }}
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Run transaction_recording
+        run: ./build/examples/transaction_recording/transaction_recording

--- a/third_party/cci-1.0.1/cci/cfg/cci_param_typed.h
+++ b/third_party/cci-1.0.1/cci/cfg/cci_param_typed.h
@@ -31,6 +31,14 @@
  * @author Enrico Galli, Intel
  * @author Guillaume Delbergue, GreenSocs / Ericsson
  */
+
+#if defined(__clang__) || \
+   (defined(__GNUC__) && ((__GNUC__ * 1000 + __GNUC_MINOR__) >= 4006))
+// ignore warning about hidden "register_post_read_callback()" overloads
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
 CCI_OPEN_NAMESPACE_
 
 // Forward declaration
@@ -988,4 +996,10 @@ template <typename T, cci_param_mutable_type TM = CCI_MUTABLE_PARAM>
 using cci_param = cci_param_typed<T,TM>;
 
 CCI_CLOSE_NAMESPACE_
+
+#if defined(__clang__) || \
+   (defined(__GNUC__) && ((__GNUC__ * 1000 + __GNUC_MINOR__) >= 4006))
+#pragma GCC diagnostic pop
+#endif
+
 #endif //CCI_CFG_CCI_PARAM_TYPED_H_INCLUDED_

--- a/third_party/cci-1.0.1/cci/core/cci_value.h
+++ b/third_party/cci-1.0.1/cci/core/cci_value.h
@@ -764,7 +764,7 @@ class cci_value_map_elem_cref
   template<typename U> friend class cci_impl::value_iterator_impl;
   typedef cci_impl::value_ptr<cci_value_map_elem_cref> proxy_ptr;
 
-  typedef void value_type; // TODO: add  explicit value_type 
+  using value_type = cci_value_map_elem_cref;
 public:
   typedef cci_value_map_elem_cref const_reference;
   typedef cci_value_map_elem_ref  reference;
@@ -791,7 +791,7 @@ class cci_value_map_elem_ref
 {
   template<typename U> friend class cci_impl::value_iterator_impl;
   typedef cci_impl::value_ptr<cci_value_map_elem_ref> proxy_ptr;
-  typedef void value_type; // TODO: add  explicit value_type
+  using value_type = cci_value_map_elem_ref;
 public:
   typedef cci_value_map_elem_cref const_reference;
   typedef cci_value_map_elem_ref  reference;

--- a/third_party/cci-1.0.1/cci/core/cci_value_iterator.h
+++ b/third_party/cci-1.0.1/cci/core/cci_value_iterator.h
@@ -71,11 +71,11 @@ template<typename T> class value_iterator_impl
 {
 public:
   // std::iterator_traits types
-  typedef T reference;  // return by value!
-  typedef value_ptr<T> pointer;    // return proxy pointer
-  typedef typename T::value_type value_type; // "real" value type
-  typedef std::ptrdiff_t difference_type;
-  typedef std::random_access_iterator_tag iterator_category;
+  using reference           = T;    // return by value!
+  using pointer             = value_ptr<T>; // return proxy pointer
+  using value_type          = typename T::value_type;   // "real" value type
+  using difference_type     = std::ptrdiff_t;
+  using iterator_category   = std::random_access_iterator_tag;
 
 protected:
   typedef void* impl_type; //  type-punned pointer for now
@@ -130,11 +130,11 @@ private:
 public:
   /// @name C++ standard iterator types
   ///@{
-  typedef typename impl::value_type        value_type;
-  typedef typename impl::pointer           pointer;
-  typedef typename impl::reference         reference;
-  typedef typename impl::difference_type   difference_type;
-  typedef typename impl::iterator_category iterator_category;
+  using value_type          = typename impl::value_type;
+  using pointer             = typename impl::pointer;
+  using reference           = typename impl::reference;
+  using difference_type     = typename impl::difference_type;
+  using iterator_category   = typename impl::iterator_category;
   ///@}
 
   /// constructs an invalid iterator (non-dereferencable, non-incrementable)

--- a/third_party/scv-tr/src/scv-tr/scv_introspection.h
+++ b/third_party/scv-tr/src/scv-tr/scv_introspection.h
@@ -3252,8 +3252,8 @@ public:
 // ----------------------------------------
 template <typename T> class scv_extensions<scv_extensions<T>> : public scv_extensions<T> {
 public:
-    scv_extensions<scv_extensions<T>>() {}
-    scv_extensions<scv_extensions<T>>(const scv_extensions<T>& rhs)
+    scv_extensions() {}
+    scv_extensions(const scv_extensions<T>& rhs)
     : scv_extensions<T>(rhs) {}
     virtual ~scv_extensions() {}
     scv_extensions& operator=(const scv_extensions<T>& rhs) { return scv_extensions<T>::operator=(rhs); }


### PR DESCRIPTION
## Summary

This PR updates SystemC-Components to support compilation with C++20, in addition to existing support for C++11, C++14, and C++17. The main change is a minimal, two-line update in scv_introspection.h to ensure compatibility with newer C++ standards.

## Motivation

- **C++20 support:** Modern toolchains and projects are increasingly adopting C++20. Ensuring SystemC-Components builds and runs correctly with C++20 broadens its usability and future-proofs the codebase.
- **Maintain backward compatibility:** The change preserves support for C++11, C++14, and C++17.

## Testing

- **CI coverage:** Added GitHub Actions CI to verify build and test success across C++11, C++14, C++17, and C++20 using an example program.
- **Demonstration of issue:**  
  [CI run showing failure on C++20](https://github.com/churley-qcom/SystemC-Components/actions/runs/15984644829) but passing on earlier standards.
- **Demonstration of fix:**  
  [CI run showing pass for all tested C++ versions](https://github.com/churley-qcom/SystemC-Components/actions/runs/16036006656) after this change.

## Dependency Updates

- **LWTR4SC:** Temporarily pointed .gitmodules to my fork ([churley-qcom/LWTR4SC](https://github.com/churley-qcom/LWTR4SC.git)) with a pending PR ([Minres/LWTR4SC#2](https://github.com/Minres/LWTR4SC/pull/2)) for C++20 compatibility.
- **CCI:** Updated the bundled CCI code to match the latest changes from the Accellera repo ([commit 3f0b24d](https://github.com/accellera-official/cci/commit/3f0b24dc5af37afea5012273a566237757cef83e)).

## Code Change

- **File:** scv_introspection.h
- **Change:** Resolve C++20 parsing ambiguity with nested template names.

## Impact

- No API changes.
- No behavioral changes.
- No new dependencies.
