### PR TITLE
fix: build error in util/logging.h

### DIFF
--- a/src/common/util/logging.h
+++ b/src/common/util/logging.h
@@ -186,7 +186,7 @@ public:
         for(unsigned int i = NONE; i <= TRACE; i++)
             if(!strncasecmp(level.c_str(), (const char*)(get_log_level_cstr() + i), strlen((const char*)get_log_level_cstr() + i)))
                 return static_cast<log_level>(i);
-        Log<T>().Get(WARN) << "Unknown logging level '" << level << "'. Using INFO level as default.";
+        Log<T>().get(WARN) << "Unknown logging level '" << level << "'. Using INFO level as default.";
         return INFO;
     }
     /**


### PR DESCRIPTION
I got a build error regarding a log call:
```
/home/derek/Git/SystemC-Components/src/common/util/logging.h:189:18: Fehler: »class logging::Log<T>« hat kein Element namens »Get«; meinten Sie »get«? [-Wtemplate-body]
  189 |         Log<T>().Get(WARN) << "Unknown logging level '" << level << "'. Using INFO level as default.";
      |                  ^~~
      |                  get
``