### PR TITLE
fix: support Xcelium SCC installed-package flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,34 @@ if(SystemC_FOUND)
         COMPATIBILITY AnyNewerVersion
     )
 
+    if(USE_NCSC_SYSTEMC3)
+        set(SCC_SYSTEMC_DEP "set(USE_NCSC_SYSTEMC ON)\nset(USE_NCSC_SYSTEMC3 ON)\nfind_dependency(XMSystemC)\n")
+    elseif(USE_NCSC_SYSTEMC)
+        set(SCC_SYSTEMC_DEP "set(USE_NCSC_SYSTEMC ON)\nfind_dependency(XMSystemC)\n")
+    elseif(USE_CWR_SYSTEMC)
+        set(SCC_SYSTEMC_DEP "find_dependency(SLSSystemC)\n")
+    elseif(USE_VCS_SYSTEMC)
+        set(SCC_SYSTEMC_DEP "find_dependency(VCSSystemC)\n")
+    elseif(USE_MTI_SYSTEMC)
+        set(SCC_SYSTEMC_DEP "find_dependency(MTISystemC)\n")
+    else()
+        set(SCC_SYSTEMC_DEP "find_dependency(SystemCLanguage)\n")
+    endif()
+
+    set(SCC_OPTIONAL_DEPS "")
+    if(TARGET ZLIB::ZLIB)
+        string(APPEND SCC_OPTIONAL_DEPS "find_dependency(ZLIB)\n")
+    endif()
+    if(TARGET BZip2::BZip2)
+        string(APPEND SCC_OPTIONAL_DEPS "find_dependency(BZip2)\n")
+    endif()
+    if(TARGET LibLZMA::LibLZMA)
+        string(APPEND SCC_OPTIONAL_DEPS "find_dependency(LibLZMA)\n")
+    endif()
+    if(TARGET zstd::libzstd_static)
+        string(APPEND SCC_OPTIONAL_DEPS "find_dependency(zstd CONFIG)\n")
+    endif()
+
     configure_package_config_file(
         ${CMAKE_CURRENT_LIST_DIR}/cmake/scc-config.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/scc-config.cmake

--- a/cmake/scc-config.cmake.in
+++ b/cmake/scc-config.cmake.in
@@ -1,10 +1,12 @@
 @PACKAGE_INIT@
 include(CMakeFindDependencyMacro)
 
-find_dependency(SystemCLanguage)
+list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/share/cmake")
+@SCC_SYSTEMC_DEP@
 find_dependency(RapidJSON)
 find_dependency(lwtr)
 find_dependency(fstapi)
+@SCC_OPTIONAL_DEPS@
 find_dependency(Boost COMPONENTS date_time filesystem)
 find_dependency(spdlog)
 find_dependency(lz4)

--- a/contrib/install_wo_conan.sh
+++ b/contrib/install_wo_conan.sh
@@ -8,16 +8,25 @@ SCRIPTDIR=`dirname "$SCRIPT"`
 SCRIPTNAME=`basename "$SCRIPT"`
 
 function print_help {
-    echo "Usage: $SCRIPTNAME [-h] [-c] <install dir>"
+    echo "Usage: $SCRIPTNAME [-h] [-c] [--deps_only] <install dir>"
     echo "Build SCC installation from tar files"
     echo "Optional cli arguments:"
     echo "  -h              print help"
     echo "  -c              clean build and install directory before building"
+    echo "  --deps_only     build only third-party dependencies, not SystemC or SCC"
 }
 
 CLEAN=0
+DEPS_ONLY=0
 
 while [ $# -gt 0 ]; do
+    case "$1" in
+        --deps_only)
+            DEPS_ONLY=1
+            shift
+            continue
+            ;;
+    esac
     unset OPTIND
     unset OPTARG
     while getopts hc  options; do
@@ -218,6 +227,8 @@ build_fmt
 build_spdlog
 build_yamlcpp
 build_zstd
-build_systemc
-build_systemc_ams
-build_scc
+if [ ${DEPS_ONLY} -eq 0 ]; then
+    build_systemc
+    build_systemc_ams
+    build_scc
+fi

--- a/src/sysc/tlm/scc/tlm_signal_gp.h
+++ b/src/sysc/tlm/scc/tlm_signal_gp.h
@@ -265,7 +265,11 @@ inline tlm_extension_base* tlm_generic_payload_base::set_auto_extension(unsigned
     tlm_extension_base* tmp = m_extensions[index];
     m_extensions[index] = ext;
     if(!tmp)
+#ifdef NCSC
+        m_extensions.insert_in_cache(index);
+#else
         m_extensions.insert_in_cache(&m_extensions[index]);
+#endif
     sc_assert(m_mm != 0);
     return tmp;
 }
@@ -283,7 +287,11 @@ inline void tlm_generic_payload_base::clear_extension(unsigned int index) {
 inline void tlm_generic_payload_base::release_extension(unsigned int index) {
     sc_assert(index < m_extensions.size());
     if(m_mm) {
+#ifdef NCSC
+        m_extensions.insert_in_cache(index);
+#else
         m_extensions.insert_in_cache(&m_extensions[index]);
+#endif
     } else {
         m_extensions[index]->free();
         m_extensions[index] = static_cast<tlm_extension_base*>(0);


### PR DESCRIPTION
This fixes the SCC installed-package flow for Xcelium/NCSC builds.

Changes:
- use the NCSC-compatible TLM extension cache insertion form only for NCSC builds, while preserving the existing OSCI/default path.
- generate the installed SCC package dependency on the configured SystemC provider, so Xcelium builds re-find XMSystemC instead of SystemCLanguage.
- re-find optional public compression dependencies from the installed package config when they are linked into exported targets.
- add a minimal --deps_only mode to install_wo_conan.sh so third-party dependencies can be built separately from SystemC/SCC and reused by a direct CMake SCC build.