### PR TITLE
Update sparse_array.h operator() and is_allocated to support 64bit ad…

### DIFF
--- a/src/common/util/sparse_array.h
+++ b/src/common/util/sparse_array.h
@@ -42,7 +42,7 @@ public:
 
     static constexpr uint64_t page_size = (1 << PAGE_ADDR_BITS);
 
-    static constexpr unsigned page_count = (SIZE + page_size - 1) / page_size;
+    static constexpr uint64_t page_count = (SIZE + page_size - 1) / page_size;
 
     static constexpr uint64_t page_addr_width = PAGE_ADDR_BITS;
 

--- a/src/common/util/sparse_array.h
+++ b/src/common/util/sparse_array.h
@@ -77,7 +77,7 @@ public:
      * @param page_nr the page number ot fetch
      * @return reference to page
      */
-    page_type& operator()(uint32_t page_nr) {
+    page_type& operator()(uint64_t page_nr) {
         assert(page_nr < page_count);
         if(arr[page_nr] == nullptr)
             arr.at(page_nr) = new page_type();
@@ -89,9 +89,9 @@ public:
      * @param addr the address to check
      * @return true if the page is allocated
      */
-    bool is_allocated(uint32_t addr) {
+    bool is_allocated(uint64_t addr) {
         assert(addr < SIZE);
-        T nr = addr >> PAGE_ADDR_BITS;
+        uint64_t nr = addr >> PAGE_ADDR_BITS;
         return arr.at(nr) != nullptr;
     }
     /**


### PR DESCRIPTION
…dresses

The is_allocated function was set to uint32_t and with T nr truncated addresses >= 4GB. Chaning both to uint64_t supports 64-bit addresses. Same applies to operator.