### PR TITLE
At router findings

### DIFF
--- a/src/components/scc/at_router/nb_arbiter.h
+++ b/src/components/scc/at_router/nb_arbiter.h
@@ -150,7 +150,7 @@ private:
                             wait((cycles + 1) * clk_period);
                         } else
                             wait(t);
-                        if(status == tlm::TLM_COMPLETED || 
+                        if(status == tlm::TLM_COMPLETED ||
                            (status == tlm::TLM_UPDATED && (phase == tlm::BEGIN_RESP || phase == tlm::END_RESP))) {
                             auto t_resp = sc_core::SC_ZERO_TIME;
                             if(status == tlm::TLM_COMPLETED) {

--- a/src/components/scc/at_router/nb_arbiter.h
+++ b/src/components/scc/at_router/nb_arbiter.h
@@ -75,7 +75,9 @@ struct nb_arbiter : public tlm::tlm_bw_nonblocking_transport_if<typename TYPES::
             if(res != tlm::TLM_ACCEPTED)
                 return res;
             phase = tlm::END_RESP;
-            auto cycles = trans.is_read() ? (trans.get_data_length() * 8 + buswidth - 1) / buswidth : 1;
+            // support SCC::LT template parameter for buswidth (otherwise divide by zero)
+            const unsigned width = buswidth ? buswidth : 64u;
+            auto cycles = trans.is_read() ? (trans.get_data_length() * 8 + width - 1) / width : 1;
             t = t + (cycles * clk_if->read()); // - 1_ps;
             source_by_tx.erase(reinterpret_cast<uintptr_t>(&trans));
             return tlm::TLM_COMPLETED;
@@ -88,7 +90,9 @@ struct nb_arbiter : public tlm::tlm_bw_nonblocking_transport_if<typename TYPES::
             if(phase == tlm::BEGIN_REQ) {
                 que.notify(tlm::scc::tlm_gp_shared_ptr(&trans), t);
                 phase = tlm::END_REQ;
-                auto cycles = trans.is_write() ? (trans.get_data_length() * 8 + owner->buswidth - 1) / owner->buswidth : 1;
+                // support SCC::LT template paramter for buswidth (otherwise divide by zero)
+                const unsigned width = owner->buswidth ? owner->buswidth : 64u;
+                auto cycles = trans.is_write() ? (trans.get_data_length() * 8 + width - 1) / width : 1;
                 t = t + (cycles * owner->clk_if->read()); // - 1_ps;
                 return tlm::TLM_UPDATED;
             } else if(phase == tlm::END_RESP) {
@@ -146,9 +150,12 @@ private:
                             wait((cycles + 1) * clk_period);
                         } else
                             wait(t);
-                        if(status == tlm::TLM_UPDATED && (phase == tlm::BEGIN_RESP || phase == tlm::END_RESP)) {
+                        if(status == tlm::TLM_COMPLETED || (status == tlm::TLM_UPDATED && (phase == tlm::BEGIN_RESP || phase == tlm::END_RESP))) {
                             auto t_resp = sc_core::SC_ZERO_TIME;
-                            tport[i].bw->nb_transport_bw(*trans, phase, t_resp);
+                            if(status == tlm::TLM_COMPLETED) {
+                                phase = tlm::BEGIN_RESP;
+                            }
+                            tport[last_selected].bw->nb_transport_bw(*trans, phase, t_resp);
                         }
                         break;
                     }

--- a/src/components/scc/at_router/nb_arbiter.h
+++ b/src/components/scc/at_router/nb_arbiter.h
@@ -150,7 +150,8 @@ private:
                             wait((cycles + 1) * clk_period);
                         } else
                             wait(t);
-                        if(status == tlm::TLM_COMPLETED || (status == tlm::TLM_UPDATED && (phase == tlm::BEGIN_RESP || phase == tlm::END_RESP))) {
+                        if(status == tlm::TLM_COMPLETED || 
+                           (status == tlm::TLM_UPDATED && (phase == tlm::BEGIN_RESP || phase == tlm::END_RESP))) {
                             auto t_resp = sc_core::SC_ZERO_TIME;
                             if(status == tlm::TLM_COMPLETED) {
                                 phase = tlm::BEGIN_RESP;

--- a/src/components/scc/at_router/nb_decoder.h
+++ b/src/components/scc/at_router/nb_decoder.h
@@ -54,6 +54,7 @@ struct nb_decoder : public tlm::tlm_fw_nonblocking_transport_if<typename TYPES::
                     phase = tlm::END_RESP;
                 return tlm::TLM_COMPLETED;
             }
+            idx = default_idx;
         } else if(tranges[idx].remap) {
             trans.set_address(trans.get_address() - (tranges[idx].remap ? tranges[idx].base : 0));
         }

--- a/src/components/scc/at_router/nb_decoder.h
+++ b/src/components/scc/at_router/nb_decoder.h
@@ -48,10 +48,12 @@ struct nb_decoder : public tlm::tlm_fw_nonblocking_transport_if<typename TYPES::
         auto addr = trans.get_address();
         auto idx = decoder.getEntry(addr);
         if(idx == decoder.null_entry) {
-            trans.set_response_status(tlm::TLM_ADDRESS_ERROR_RESPONSE);
-            if(phase == tlm::BEGIN_REQ)
-                phase = tlm::END_RESP;
-            return tlm::TLM_COMPLETED;
+            if(default_idx == std::numeric_limits<size_t>::max()) {
+                trans.set_response_status(tlm::TLM_ADDRESS_ERROR_RESPONSE);
+                if(phase == tlm::BEGIN_REQ)
+                    phase = tlm::END_RESP;
+                return tlm::TLM_COMPLETED;
+            }
         } else if(tranges[idx].remap) {
             trans.set_address(trans.get_address() - (tranges[idx].remap ? tranges[idx].base : 0));
         }
@@ -61,6 +63,8 @@ struct nb_decoder : public tlm::tlm_fw_nonblocking_transport_if<typename TYPES::
     tlm::tlm_sync_enum nb_transport_bw(tlm_generic_payload& trans, tlm_phase& phase, sc_core::sc_time& t) override {
         return tport.bw->nb_transport_bw(trans, phase, t);
     }
+
+    void set_default_target(size_t idx) { default_idx = idx; }
 
 private:
     i_port<TYPES>& add_isckt() {
@@ -72,6 +76,8 @@ private:
 
     util::range_lut<unsigned> const& decoder;
     std::vector<range_entry> const& tranges;
+
+    size_t default_idx = std::numeric_limits<size_t>::max();
 };
 } // namespace at_router
 } // namespace scc

--- a/src/components/scc/at_router/nb_router.h
+++ b/src/components/scc/at_router/nb_router.h
@@ -43,6 +43,11 @@ template <typename TYPES = tlm::tlm_base_protocol_types> struct nb_router {
         for(auto& a : arbiter)
             a.clk_if = clk_if;
     }
+
+    void set_default_target(size_t idx) {
+        for(auto& d : decoder)
+            d.set_default_target(idx);
+    }
 };
 
 template <typename TYPES = tlm::tlm_base_protocol_types>

--- a/src/components/scc/router.h
+++ b/src/components/scc/router.h
@@ -413,6 +413,7 @@ void router<BUSWIDTH, TARGET_SOCKET_TYPE>::invalidate_direct_mem_ptr(int id, ::s
 template <unsigned BUSWIDTH, typename TARGET_SOCKET_TYPE> void router<BUSWIDTH, TARGET_SOCKET_TYPE>::before_end_of_elaboration() {
     if(creator) {
         rt = creator(BUSWIDTH, target.size(), initiator.size(), addr_decoder, tranges, clk_period);
+        rt->set_default_target(default_idx);
         for(auto i = 0u; i < target.size(); ++i) {
             auto& igress = rt->igress[i];
             target[i].register_nb_transport_fw(


### PR DESCRIPTION
Added findings for AT router which caused the system to not compile, get stuck or fail.
- Added set_default_target like b_transport mode
- Added support for SCC::LT which lead to divide by zero fault
- Added TLM_COMPLETED callback when artibtrating so the oposite site does not get stuck waiting for the next repsonse to be able to be sent